### PR TITLE
Fix tests + Docs

### DIFF
--- a/parshift/__init__.py
+++ b/parshift/__init__.py
@@ -16,6 +16,6 @@ __all__ = [
 
 
 from parshift.annotation import annotate, conv2turns, pshift_class, read_ccsv
+from parshift.oo_parshift import Parshift
 from parshift.plotting import frequency_treemap
 from parshift.statistics import cond_probs
-from parshift.oo_parshift import Parshift

--- a/parshift/annotation.py
+++ b/parshift/annotation.py
@@ -341,7 +341,7 @@ def pshift_class(pshift: str) -> str:
     """Returns the participation shift class given a participation shift code.
 
     Arguments:
-        pshift_code: Participation shift code (e.g A0-XA).
+        pshift: Participation shift code (e.g A0-XA).
 
     Returns:
         Participation shift classe in given the participation shift code (either

--- a/parshift/annotation.py
+++ b/parshift/annotation.py
@@ -153,7 +153,6 @@ def conv2turns(conv_df: pd.DataFrame) -> List[Dict[str, Any]]:
 
 
 def _pshift_code(label: str) -> str:
-
     # split the label into 4 parts
     a = label.split(",")[0].split("to")[0].replace(" ", "")
     b = label.split(",")[0].split("to")[1].replace(" ", "")

--- a/parshift/oo_parshift.py
+++ b/parshift/oo_parshift.py
@@ -83,11 +83,8 @@ class Parshift:
 
         Arguments:
             type: Column name to be used to plot the treemap, either `"Pshift"`
-            (default) or `"Pshift_class"`.
-            N: Number of parts to split the conversation into. Default is 1 (all conversation).
-                `N` should be between 1 and 4.
-            **kwargs: Keyword parameters passed to Pandas
-                [`read_csv()`][pandas.read_csv] function.
+                (default) or `"Pshift_class"`.
+            save: Whether to save the plot.
 
         """
 
@@ -139,6 +136,8 @@ class Parshift:
         plt.show()
 
     def get_stats(self):
+        """Returns the statistics."""
+
         if self.stats is None:
             raise ValueError(
                 "Parshift.stats is None. Please run Parshift.process() first."

--- a/parshift/oo_parshift.py
+++ b/parshift/oo_parshift.py
@@ -3,14 +3,16 @@
 # at http://opensource.org/licenses/MIT)
 
 from __future__ import annotations
-from pandas._typing import FilePath, ReadCsvBuffer
-from typing import Any
+
+from typing import Any, List
+
 import matplotlib.pyplot as plt
 import pandas as pd
+from pandas._typing import FilePath, ReadCsvBuffer
 
-from .annotation import read_ccsv, annotate
-from .statistics import cond_probs
+from .annotation import annotate, read_ccsv
 from .plotting import frequency_treemap
+from .statistics import cond_probs
 
 # from parshift.annotation import read_ccsv, annotate
 # from parshift.statistics import cond_probs
@@ -18,11 +20,15 @@ from .plotting import frequency_treemap
 
 
 class Parshift:
-    def __init__(self):
+    def __init__(
+        self,
+        annotation: pd.DataFrame | None = None,
+        stats: pd.DataFrame | List[pd.DataFrame] | None = None,
+    ):
         """Parshift initialization"""
 
-        self.annotation: pd.DataFrame = None
-        self.stats: pd.DataFrame | list[pd.DataFrame] = None
+        self.annotation = annotation
+        self.stats = stats
 
     def process(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ norecursedirs = [
     ".tox",
     ".git",
     "__pycache__" ]
-testpaths = [ "tests" ]
+testpaths = ["parshift", "tests"]
 
 [tool.mypy]
 python_version = 3.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ norecursedirs = [
     ".tox",
     ".git",
     "__pycache__" ]
-testpaths = ["parshift", "tests"]
+testpaths = [ "tests" ]
 
 [tool.mypy]
 python_version = 3.8

--- a/tests/test_oo_parshift.py
+++ b/tests/test_oo_parshift.py
@@ -2,10 +2,11 @@
 # Distributed under the MIT License (See accompanying file LICENSE or copy
 # at http://opensource.org/licenses/MIT)
 
-from parshift import Parshift
-import pandas as pd
 import matplotlib.pyplot as plt
+import pandas as pd
 import pytest
+
+from parshift import Parshift
 
 
 def test_process(file_csv_good):
@@ -29,7 +30,6 @@ def test_process_error(file_csv_good, N, expecterr):
 
 
 def test_get_plot(file_csv_good, monkeypatch):
-
     # Patch plt.show() so that it doesn't do anything, otherwise tests will hang
     monkeypatch.setattr(plt, "show", lambda *args, **kwargs: None)
 

--- a/tests/test_oo_parshift.py
+++ b/tests/test_oo_parshift.py
@@ -28,7 +28,11 @@ def test_process_error(file_csv_good, N, expecterr):
         model.process(file_csv_good["csv_in"], **(file_csv_good["kwargs"]), N=N)
 
 
-def test_get_plot(file_csv_good):
+def test_get_plot(file_csv_good, monkeypatch):
+
+    # Patch plt.show() so that it doesn't do anything, otherwise tests will hang
+    monkeypatch.setattr(plt, "show", lambda *args, **kwargs: None)
+
     model = Parshift()
     model.process(file_csv_good["csv_in"], **(file_csv_good["kwargs"]))
     model.get_plot()


### PR DESCRIPTION
### Contributions:

- Fix tests (which were hanging in CI because there was no one there to close the plot windows) by mocking out `plt.show()`
- Fix mypy warnings in the OO interface module
- Fix missing documentation / docstrings

### Suggestions

- In `Parshift.get_plot()` replace the `save` boolean parameter with the `filename: str | None = None` parameter. If the user wants to save the file, then they can specify the filename directly, and we avoid having hard-coded filenames.
- Whether the previous item is applied or not, add tests to the _save file_ functionality, which is not currently being tested.