### PR TITLE
Update tests for Python 3.12

### DIFF
--- a/.github/workflows/cov.yml
+++ b/.github/workflows/cov.yml
@@ -3,10 +3,10 @@ name: Coverage
 on:
   pull_request:
     branches: [main]
-    paths: [ 'parshift/**', 'tests/**' ]
+    paths: [ 'parshift/**', 'tests/**', '.github/workflows/cov.yml' ]
   push:
     branches: [main]
-    paths: [ 'parshift/**', 'tests/**' ]
+    paths: [ 'parshift/**', 'tests/**', '.github/workflows/cov.yml' ]
     tags: '*'
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['3.8', '3.11']
+        version: ['3.8', '3.12']
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - name: Clone repository

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,10 +3,10 @@ name: Tests
 on:
   pull_request:
     branches: [main]
-    paths: [ 'parshift/**', 'tests/**', 'pyproject.toml' ]
+    paths: [ 'parshift/**', 'tests/**', 'pyproject.toml', '.github/workflows/tests.yml' ]
   push:
     branches: [main]
-    paths: [ 'parshift/**', 'tests/**', 'pyproject.toml' ]
+    paths: [ 'parshift/**', 'tests/**', 'pyproject.toml', '.github/workflows/tests.yml' ]
     tags: '*'
 
 jobs:


### PR DESCRIPTION
- All tests pass with new Python 3.12
- Suggest releasing new ParShift version 1.0.1 (just update version in `pyproject.toml`, push, then create a release in GitHub. Everything else is automatic.