### PR TITLE
Fix software title in CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@
 # Visit https://bit.ly/cffinit to generate yours today!
 
 cff-version: 1.2.0
-title: pyclugen
+title: parshift
 message: >-
   If you use this software, please cite it using the
   metadata from this file.


### PR DESCRIPTION
In the file CITATITION.cff the title appeared as "pyclugen", when it should be "parshift". This pull request fixes that.