### PR TITLE
Update to v1.0.2

### DIFF
--- a/.github/workflows/cov.yml
+++ b/.github/workflows/cov.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup latest Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         pip install pip --upgrade
@@ -26,6 +26,6 @@ jobs:
     - name: Test with pytest and create coverage report
       run: pytest --cov=parshift --cov-report=xml
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
-        files: ./coverage.xml
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: true
       - name: Build docs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout package
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install build and publish dependencies
         run: |
           pip3 install --upgrade build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,11 +16,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['3.8', '3.12']
+        version: ['3.9', '3.13']
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - name: Clone repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup latest Python
       uses: actions/setup-python@v4
       with:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -68,4 +68,4 @@ nav:
   - Reference: reference.md
   - Development: dev.md
 
-copyright: Copyright &copy; 2023 Maintained by <a href="https://github.com/bdfsaraiva">Bruno D. Ferreira-Saraiva</a>.
+copyright: Copyright &copy; 2023-2025 Maintained by <a href="https://github.com/bdfsaraiva">Bruno D. Ferreira-Saraiva</a>.

--- a/parshift/annotation.py
+++ b/parshift/annotation.py
@@ -125,7 +125,7 @@ def conv2turns(conv_df: pd.DataFrame) -> List[Dict[str, Any]]:
             and conversation[turn - 1][last_col] == row[last_col]
         ):
             msg_join = ". ".join(
-                [conversation[turn - 1]["utterance"], row["utterance"]]
+                [conversation[turn - 1]["utterance"], str(row["utterance"])]
             )
             list_id = conversation[turn - 1]["utterance_ids"] + [row["utterance_id"]]
             conversation[turn - 1]["utterance_ids"] = list_id

--- a/parshift/annotation.py
+++ b/parshift/annotation.py
@@ -143,11 +143,13 @@ def conv2turns(conv_df: pd.DataFrame) -> List[Dict[str, Any]]:
                     "utterance_ids": [id],
                     "speaker_id": speaker_id,
                     "utterance": utterance,
-                    last_col: last_col_val
-                    if last_col_val != ""
-                    and last_col_val != None
-                    and last_col_val != "None"
-                    else None,
+                    last_col: (
+                        last_col_val
+                        if last_col_val != ""
+                        and last_col_val != None
+                        and last_col_val != "None"
+                        else None
+                    ),
                 }
             )
 

--- a/parshift/plotting.py
+++ b/parshift/plotting.py
@@ -2,13 +2,14 @@
 # Distributed under the MIT License (See accompanying file LICENSE or copy
 # at http://opensource.org/licenses/MIT)
 
+from typing import Optional
+
 import matplotlib
 import matplotlib.pyplot as plt
 import pandas as pd
 import squarify
 
 from .annotation import pshift_class
-from typing import Optional
 
 
 def frequency_treemap(

--- a/parshift/statistics.py
+++ b/parshift/statistics.py
@@ -153,35 +153,47 @@ def cond_probs(pshift_codes: pd.DataFrame) -> pd.DataFrame:
         if key.split("-")[0] == "A0":
             if key not in ["A0-AY", "AB-A0", "AB-AY", "A0-A0"]:
                 cond_prob[key] = {
-                    "CP": round(freq_table[key] / frequency_table_and_counts[1], 2)
-                    if frequency_table_and_counts[1] != 0
-                    else 0,
-                    "CPeTC": round(freq_table[key] / frequency_table_and_counts[3], 2)
-                    if frequency_table_and_counts[3] != 0
-                    else 0,
+                    "CP": (
+                        round(freq_table[key] / frequency_table_and_counts[1], 2)
+                        if frequency_table_and_counts[1] != 0
+                        else 0
+                    ),
+                    "CPeTC": (
+                        round(freq_table[key] / frequency_table_and_counts[3], 2)
+                        if frequency_table_and_counts[3] != 0
+                        else 0
+                    ),
                 }
             else:
                 cond_prob[key] = {
-                    "CP": round(freq_table[key] / frequency_table_and_counts[1], 2)
-                    if frequency_table_and_counts[1] != 0
-                    else 0,
+                    "CP": (
+                        round(freq_table[key] / frequency_table_and_counts[1], 2)
+                        if frequency_table_and_counts[1] != 0
+                        else 0
+                    ),
                     "CPeTC": "",
                 }
         else:
             if key not in ["A0-AY", "AB-A0", "AB-AY", "A0-A0"]:
                 cond_prob[key] = {
-                    "CP": round(freq_table[key] / frequency_table_and_counts[2], 2)
-                    if frequency_table_and_counts[2] != 0
-                    else 0,
-                    "CPeTC": round(freq_table[key] / frequency_table_and_counts[4], 2)
-                    if frequency_table_and_counts[4] != 0
-                    else 0,
+                    "CP": (
+                        round(freq_table[key] / frequency_table_and_counts[2], 2)
+                        if frequency_table_and_counts[2] != 0
+                        else 0
+                    ),
+                    "CPeTC": (
+                        round(freq_table[key] / frequency_table_and_counts[4], 2)
+                        if frequency_table_and_counts[4] != 0
+                        else 0
+                    ),
                 }
             else:
                 cond_prob[key] = {
-                    "CP": round(freq_table[key] / frequency_table_and_counts[2], 2)
-                    if frequency_table_and_counts[2] != 0
-                    else 0,
+                    "CP": (
+                        round(freq_table[key] / frequency_table_and_counts[2], 2)
+                        if frequency_table_and_counts[2] != 0
+                        else 0
+                    ),
                     "CPeTC": "",
                 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["parshift"]
 
 [project]
 name = "parshift"
-version = "1.0.1.9000"
+version = "1.0.2"
 description = "Python package based on Gibson's framework (2003) for turn-taking in group conversation analysis."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,10 @@ packages = ["parshift"]
 
 [project]
 name = "parshift"
-version = "1.0.1"
+version = "1.0.1.9000"
 description = "Python package based on Gibson's framework (2003) for turn-taking in group conversation analysis."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = [
     "python",
     "conversation-analysis",
@@ -62,7 +62,7 @@ norecursedirs = [
 testpaths = ["parshift", "tests"]
 
 [tool.mypy]
-python_version = 3.8
+python_version = "3.9"
 
 [[tool.mypy.overrides]]
 module = [ "squarify", "matplotlib", "matplotlib.pyplot"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,13 +4,13 @@
 
 """Fixtures to be used by test functions."""
 
-from numpy.typing import DTypeLike
 from os import PathLike
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import pytest
+from numpy.typing import DTypeLike
 
 # Files containing good conversations, optional parameters required to open them,
 # and CSV file containing respective conversation after annotation

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@
 
 """Fixtures to be used by test functions."""
 
+from numpy.typing import DTypeLike
 from os import PathLike
 from pathlib import Path
 
@@ -92,14 +93,14 @@ _bad_params_read_ccsv = [
 
 
 # Mandatory columns and types of conversation data frame
-_p_shift_cols_mandatory = {
+_p_shift_cols_mandatory: dict[str, DTypeLike] = {
     "utterance_id": np.int64,
     "speaker_id": np.dtype("O"),
     "utterance": np.dtype("O"),
 }
 
 # Optional columns and types of conversation data frame
-_p_shift_cols_optional = {
+_p_shift_cols_optional: dict[str, DTypeLike] = {
     "reply_to_id": np.dtype("O"),
     "target_id": np.dtype("O"),
 }


### PR DESCRIPTION
Several updates:

- Add `py.typed` file so that third-party code can correctly use and be tested against types defined in ParShift.
- Fix several Mypy issues occurring from the issue above and newer Python versions.
- Set minimum Python version to 3.9 due to Mypy.
- Validate package with Python 3.13.

After the pull request is accepted:

- Create a token in CodeCov for ParShift.
- Add the `CODECOV_TOKEN` variable (with the value defined above in CodeCov) to GitHub -> Settings -> Secrets and variables -> Actions -> Repository secrets.
- Release version v1.0.2 on GitHub, mentioning the "Several updates" above; this will automatically release the new version on PyPi, update the docs, and update the coverage in CodeCov, hopefully.

Why is this needed:

- Apart from regular package maintenance, the fact that the package is typed allows us to better test the quality of code generated to use this package.